### PR TITLE
Drop pylint framework plugins

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install --no-deps --ignore-installed .
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,6 @@ requirements:
   run:
     - python
     - pylint >=1.5.6,<2.0.0
-    - pylint-celery >=0.3
-    - pylint-django >=0.7.2
-    - pylint-flask >=0.3
     - pylint-plugin-utils >=0.2.6
     - pylint-common >=0.2.5
     - requirements-detector >=0.4.1


### PR DESCRIPTION
Missed that `pylint-celery`, `pylint-django`, and `pylint-flask` were dropped a part of `prospector` version `0.12.8`. So dropping them in this follow-up PR.

ref: ref: https://github.com/PyCQA/prospector/commit/f866efc762c323779d283457abb86271b514d957

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy`
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
